### PR TITLE
Isolate Core Data entities on main actor

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,11 @@ let package = Package(
             name: "InjectableViewsDemo",
             targets: ["InjectableViewsDemo"]
         ),
+        // Library exposing the Core Data entities used by the macOS sample app.
+        .library(
+            name: "ProjectPlannerApp",
+            targets: ["ProjectPlannerApp"]
+        ),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.0"),
@@ -42,6 +47,12 @@ let package = Package(
         .executableTarget(
             name: "InjectableViewsDemo",
             dependencies: ["InjectableViews"]
+        ),
+
+        // Core Data entities used by the macOS sample app.
+        .target(
+            name: "ProjectPlannerApp",
+            dependencies: []
         ),
 
         .testTarget(

--- a/Sources/ProjectPlannerApp/ManagedEntity.swift
+++ b/Sources/ProjectPlannerApp/ManagedEntity.swift
@@ -1,0 +1,17 @@
+import Foundation
+import CoreData
+
+/// A common base class for Core Data entities providing a stable identifier and
+/// main-actor isolation.
+///
+/// By isolating the `Identifiable` conformance to the main actor we ensure that
+/// accessing the managed object's identifier is always performed on the correct
+/// thread and avoids data races under Swift 6's strict concurrency model.
+@MainActor
+open class ManagedEntity: NSManagedObject {
+    /// A stable unique identifier for the entity.
+    @NSManaged public var id: UUID
+}
+
+@MainActor
+extension ManagedEntity: Identifiable {}

--- a/Sources/ProjectPlannerApp/Phase.swift
+++ b/Sources/ProjectPlannerApp/Phase.swift
@@ -1,0 +1,8 @@
+import Foundation
+import CoreData
+
+/// Core Data entity representing a Phase.
+@MainActor
+public class Phase: ManagedEntity {
+    // Additional properties for Phase can be added here.
+}

--- a/Sources/ProjectPlannerApp/Plan.swift
+++ b/Sources/ProjectPlannerApp/Plan.swift
@@ -1,0 +1,8 @@
+import Foundation
+import CoreData
+
+/// Core Data entity representing a Plan.
+@MainActor
+public class Plan: ManagedEntity {
+    // Additional properties for Plan can be added here.
+}

--- a/Sources/ProjectPlannerApp/Project.swift
+++ b/Sources/ProjectPlannerApp/Project.swift
@@ -1,0 +1,8 @@
+import Foundation
+import CoreData
+
+/// Core Data entity representing a Project.
+@MainActor
+public class Project: ManagedEntity {
+    // Additional properties for Project can be added here.
+}

--- a/Sources/ProjectPlannerApp/Task.swift
+++ b/Sources/ProjectPlannerApp/Task.swift
@@ -1,0 +1,8 @@
+import Foundation
+import CoreData
+
+/// Core Data entity representing a Task.
+@MainActor
+public class Task: ManagedEntity {
+    // Additional properties for Task can be added here.
+}

--- a/Sources/ProjectPlannerApp/Team.swift
+++ b/Sources/ProjectPlannerApp/Team.swift
@@ -1,0 +1,8 @@
+import Foundation
+import CoreData
+
+/// Core Data entity representing a Team.
+@MainActor
+public class Team: ManagedEntity {
+    // Additional properties for Team can be added here.
+}


### PR DESCRIPTION
## Summary
- add ProjectPlannerApp target with main actor isolated Core Data entities
- refactor shared ManagedEntity base class that conforms to Identifiable on the main actor

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/apple/swift-syntax.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b425ac60832e9c4a2f2a8fc58b10