### PR TITLE
Add override cleanup API and tests

### DIFF
--- a/Sources/InjectableViews/OverridesMaintainer.swift
+++ b/Sources/InjectableViews/OverridesMaintainer.swift
@@ -71,4 +71,26 @@ public class OverridesMaintainer {
     public func override(for key: String) -> AnyView? {
         overrides[key]
     }
+
+    /// Removes the override for a given key if it exists.
+    ///
+    /// - Parameter key: The key associated with the override to remove.
+    ///
+    /// ### Example:
+    /// ```swift
+    /// maintainer.removeOverride(for: "childView")
+    /// ```
+    public func removeOverride(for key: String) {
+        overrides.removeValue(forKey: key)
+    }
+
+    /// Resets all overrides, clearing the overrides dictionary.
+    ///
+    /// ### Example:
+    /// ```swift
+    /// maintainer.resetOverrides()
+    /// ```
+    public func resetOverrides() {
+        overrides.removeAll()
+    }
 }

--- a/Tests/InjectableViewsTests/OverridesMaintainerTests.swift
+++ b/Tests/InjectableViewsTests/OverridesMaintainerTests.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+import XCTest
+@testable import InjectableViews
+
+// A simple container that uses OverridesMaintainer directly for testing.
+struct TestContainer: View {
+    var overridesMaintainer = OverridesMaintainer()
+
+    var childView: AnyView {
+        if let override = overridesMaintainer.override(for: "childView") {
+            return override
+        }
+        return AnyView(Text("Default View"))
+    }
+
+    var body: some View {
+        childView
+    }
+}
+
+final class OverridesMaintainerTests: XCTestCase {
+    func testOverrideInjection() {
+        var container = TestContainer()
+        // Apply override
+        container.overridesMaintainer.updateOverride(for: "childView", with: AnyView(Text("Injected View")))
+
+        let description = String(describing: container.childView)
+        XCTAssertTrue(description.contains("Injected View"), "The overridden view should be rendered instead of the default.")
+    }
+
+    func testOverrideRemoval() {
+        let maintainer = OverridesMaintainer()
+        maintainer.updateOverride(for: "childView", with: AnyView(Text("Injected")))
+        maintainer.removeOverride(for: "childView")
+        XCTAssertNil(maintainer.override(for: "childView"))
+    }
+
+    func testOverrideReset() {
+        let maintainer = OverridesMaintainer()
+        maintainer.updateOverride(for: "childView", with: AnyView(Text("Injected")))
+        maintainer.resetOverrides()
+        XCTAssertTrue(maintainer.overrides.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- support removing and resetting view overrides in `OverridesMaintainer`
- add tests demonstrating injection and cleanup behavior

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/apple/swift-syntax.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b77969ac832eade9f095f7c76284