### PR TITLE
Refactor OverridesMaintainer into actor-based model

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ The macro generates the following members:
 ```swift
 private var _overridesMaintainer = OverridesMaintainer()
 
-public func overrideView<V: View>(for key: InjectableKeys, @ViewBuilder with viewBuilder: () -> V) -> Self {
-    _overridesMaintainer.updateOverride(for: key.rawValue, with: AnyView(viewBuilder()))
+public func overrideView<V: View>(for key: InjectableKeys, @ViewBuilder with viewBuilder: () -> V) async -> Self {
+    await _overridesMaintainer.updateOverride(for: key.rawValue, with: AnyView(viewBuilder()))
     return self
 }
 

--- a/Sources/InjectableViews/MacroDefinitions.swift
+++ b/Sources/InjectableViews/MacroDefinitions.swift
@@ -45,8 +45,8 @@ import SwiftUI
 /// ```swift
 /// private var _overridesMaintainer = OverridesMaintainer()
 ///
-/// public func overrideView<V: View>(for key: InjectableKeys, @ViewBuilder with viewBuilder: () -> V) -> Self {
-///     _overridesMaintainer.updateOverride(for: key.rawValue, with: AnyView(viewBuilder()))
+/// public func overrideView<V: View>(for key: InjectableKeys, @ViewBuilder with viewBuilder: () -> V) async -> Self {
+///     await _overridesMaintainer.updateOverride(for: key.rawValue, with: AnyView(viewBuilder()))
 ///     return self
 /// }
 ///
@@ -132,10 +132,12 @@ public macro InjectableContainer() = #externalMacro(
 /// The macro generates the following computed property for the above examples:
 /// ```swift
 /// var childView: some View {
-///     if let override = _overridesMaintainer.override(for: "childView") {
-///         return override
+///     get async {
+///         if let override = await _overridesMaintainer.override(for: "childView") {
+///             return override
+///         }
+///         return AnyView(childViewBuilder())
 ///     }
-///     return AnyView(childViewBuilder())
 /// }
 /// ```
 ///

--- a/Sources/InjectableViews/OverridesMaintainer.swift
+++ b/Sources/InjectableViews/OverridesMaintainer.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 /// A shared manager for handling view overrides in the InjectableViews system.
 ///
-/// The `OverridesMaintainer` class is responsible for managing runtime overrides of views
+/// The `OverridesMaintainer` actor is responsible for managing runtime overrides of views
 /// in containers marked with `@InjectableContainer`. It stores overrides in a dictionary
 /// and provides methods to update and retrieve overrides dynamically.
 ///
@@ -35,10 +35,10 @@ import SwiftUI
 /// - Note: This class is designed to be used internally by the `InjectableViews` system.
 /// - Author: Mohamed Nassar
 /// - Since: 28/07/2025
-public class OverridesMaintainer {
+public actor OverridesMaintainer {
     /// A dictionary storing overrides for injectable views.
     /// The keys are `String` identifiers, and the values are `AnyView` instances.
-    private(set) var overrides: [String: AnyView] = [:]
+    private var overrides: [String: AnyView] = [:]
 
     /// Initializes a new instance of `OverridesMaintainer`.
     public init() {}
@@ -51,7 +51,7 @@ public class OverridesMaintainer {
     ///
     /// ### Example:
     /// ```swift
-    /// maintainer.updateOverride(for: "childView", with: AnyView(Text("Overridden View")))
+    /// await maintainer.updateOverride(for: "childView", with: AnyView(Text("Overridden View")))
     /// ```
     public func updateOverride(for key: String, with view: AnyView) {
         overrides[key] = view
@@ -64,7 +64,7 @@ public class OverridesMaintainer {
     ///
     /// ### Example:
     /// ```swift
-    /// if let override = maintainer.override(for: "childView") {
+    /// if let override = await maintainer.override(for: "childView") {
     ///     // Use the overridden view
     /// }
     /// ```

--- a/Sources/InjectableViewsMacros/InjectableContainerMacro.swift
+++ b/Sources/InjectableViewsMacros/InjectableContainerMacro.swift
@@ -114,8 +114,8 @@ public struct InjectableContainerMacro: MemberMacro {
 
         // Inject a function to update the overrides
         let updateFunction = try DeclSyntax(stringLiteral: """
-        public func overrideView<V: View>(for key: InjectableKeys, @ViewBuilder with viewBuilder: () -> V) -> Self {
-            _overridesMaintainer.updateOverride(for: key.rawValue, with: AnyView(viewBuilder()))
+        public func overrideView<V: View>(for key: InjectableKeys, @ViewBuilder with viewBuilder: () -> V) async -> Self {
+            await _overridesMaintainer.updateOverride(for: key.rawValue, with: AnyView(viewBuilder()))
             return self
         }
         """)

--- a/Sources/InjectableViewsMacros/InjectableViewMacro.swift
+++ b/Sources/InjectableViewsMacros/InjectableViewMacro.swift
@@ -38,10 +38,12 @@ import SwiftDiagnostics
 /// The macro generates the following computed property:
 /// ```swift
 /// var childView: some View {
-///     if let override = _overridesMaintainer.override(for: "childView") {
-///         return override
+///     get async {
+///         if let override = await _overridesMaintainer.override(for: "childView") {
+///             return override
+///         }
+///         return childViewBuilder()
 ///     }
-///     return childViewBuilder()
 /// }
 /// ```
 ///
@@ -112,10 +114,12 @@ public struct InjectableViewMacro: PeerMacro {
         // Generate the computed property
         let computedProperty = try DeclSyntax(stringLiteral: """
         var \(propertyName): some View {
-            if let override = _overridesMaintainer.override(for: "\(propertyName)") {
-                return override
+            get async {
+                if let override = await _overridesMaintainer.override(for: "\(propertyName)") {
+                    return override
+                }
+                return AnyView(\(identifier))
             }
-            return AnyView(\(identifier))
         }
         """)
 
@@ -154,10 +158,12 @@ public struct InjectableViewMacro: PeerMacro {
         // Generate the computed property
         let computedProperty = try DeclSyntax(stringLiteral: """
         var \(propertyName): some View {
-            if let override = _overridesMaintainer.override(for: "\(propertyName)") {
-                return override
+            get async {
+                if let override = await _overridesMaintainer.override(for: "\(propertyName)") {
+                    return override
+                }
+                return AnyView(\(name)())
             }
-            return AnyView(\(name)())
         }
         """)
 

--- a/Tests/InjectableViewsTests/InjectableContainerMacroTests.swift
+++ b/Tests/InjectableViewsTests/InjectableContainerMacroTests.swift
@@ -29,8 +29,8 @@ final class InjectableContainerMacroTests: XCTestCase {
                     case childView = "childView"
                 }
 
-                public func overrideView<V: View>(for key: InjectableKeys, @ViewBuilder with viewBuilder: () -> V) -> Self {
-                    _overridesMaintainer.updateOverride(for: key.rawValue, with: AnyView(viewBuilder()))
+                public func overrideView<V: View>(for key: InjectableKeys, @ViewBuilder with viewBuilder: () -> V) async -> Self {
+                    await _overridesMaintainer.updateOverride(for: key.rawValue, with: AnyView(viewBuilder()))
                     return self
                 }
             """,

--- a/Tests/InjectableViewsTests/InjectableViewMacroTests.swift
+++ b/Tests/InjectableViewsTests/InjectableViewMacroTests.swift
@@ -47,10 +47,12 @@ final class InjectableViewMacroTests: XCTestCase {
             """,
             expandedSource: """
             var childView: some View {
-                if let override = _overridesMaintainer.override(for: "childView") {
-                    return override
+                get async {
+                    if let override = await _overridesMaintainer.override(for: "childView") {
+                        return override
+                    }
+                    return AnyView(childViewBuilder)
                 }
-                return AnyView(childViewBuilder)
             }
             """,
             macros: ["InjectableView": InjectableViewMacro.self]
@@ -67,10 +69,12 @@ final class InjectableViewMacroTests: XCTestCase {
             """,
             expandedSource: """
             var childView: some View {
-                if let override = _overridesMaintainer.override(for: "childView") {
-                    return override
+                get async {
+                    if let override = await _overridesMaintainer.override(for: "childView") {
+                        return override
+                    }
+                    return AnyView(childViewBuilder())
                 }
-                return AnyView(childViewBuilder())
             }
             """,
             macros: ["InjectableView": InjectableViewMacro.self]

--- a/Tests/InjectableViewsTests/OverridesMaintainerConcurrencyTests.swift
+++ b/Tests/InjectableViewsTests/OverridesMaintainerConcurrencyTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+import SwiftUI
+@testable import InjectableViews
+
+final class OverridesMaintainerConcurrencyTests: XCTestCase {
+    func testConcurrentOverrideUpdates() async {
+        let maintainer = OverridesMaintainer()
+        let iterations = 100
+        await withTaskGroup(of: Void.self) { group in
+            for i in 0..<iterations {
+                group.addTask {
+                    await maintainer.updateOverride(for: "\(i)", with: AnyView(Text("\(i)")))
+                }
+            }
+        }
+        for i in 0..<iterations {
+            let value = await maintainer.override(for: "\(i)")
+            XCTAssertNotNil(value)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Replace OverridesMaintainer’s queue-based synchronization with a Swift actor
- Adjust macros to emit async APIs that interact with the actor
- Strengthen concurrency test using task groups for parallel override updates

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/apple/swift-syntax.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b770e2e8832ebd27e584d15eee4e