### PR TITLE
Add override removal and reset APIs

### DIFF
--- a/Sources/InjectableViews/MacroDefinitions.swift
+++ b/Sources/InjectableViews/MacroDefinitions.swift
@@ -13,6 +13,8 @@ import SwiftUI
 /// The macro injects the following members into the annotated type:
 /// - A private `_overridesMaintainer` property to manage runtime overrides.
 /// - A `overrideView(for:with:)` function to allow runtime view overrides.
+/// - A `removeOverride(for:)` function to remove specific overrides.
+/// - A `resetOverrides()` function to clear all overrides.
 /// - An `InjectableKeys` enum containing all injectable properties or functions for type-safe key management.
 ///
 /// ### Example Usage:
@@ -43,10 +45,20 @@ import SwiftUI
 /// #### Generated Members:
 /// The macro generates the following members:
 /// ```swift
-/// private var _overridesMaintainer = OverridesMaintainer()
+/// private let _overridesMaintainer = OverridesMaintainer()
 ///
 /// public func overrideView<V: View>(for key: InjectableKeys, @ViewBuilder with viewBuilder: () -> V) -> Self {
-///     _overridesMaintainer.updateOverride(for: key.rawValue, with: AnyView(viewBuilder()))
+///     _overridesMaintainer.overrideView(AnyView(viewBuilder()), for: key.rawValue)
+///     return self
+/// }
+///
+/// public func removeOverride(for key: InjectableKeys) -> Self {
+///     _overridesMaintainer.removeOverride(for: key.rawValue)
+///     return self
+/// }
+///
+/// public func resetOverrides() -> Self {
+///     _overridesMaintainer.resetAll()
 ///     return self
 /// }
 ///
@@ -78,7 +90,7 @@ import SwiftUI
 /// - Note: This macro must be applied to a `struct` or `class` that conforms to `View`.
 /// - Author: Mohamed Nassar
 /// - Since: 26/07/2025
-@attached(member, names: named(_overridesMaintainer), named(overrideView(for:with:)), named(InjectableKeys))
+@attached(member, names: named(_overridesMaintainer), named(overrideView(for:with:)), named(removeOverride(for:)), named(resetOverrides), named(InjectableKeys))
 public macro InjectableContainer() = #externalMacro(
     module: "InjectableViewsMacros",
     type: "InjectableContainerMacro"

--- a/Sources/InjectableViews/OverridesMaintainer.swift
+++ b/Sources/InjectableViews/OverridesMaintainer.swift
@@ -21,7 +21,7 @@ import SwiftUI
 /// ### Example Usage:
 /// ```swift
 /// let maintainer = OverridesMaintainer()
-/// maintainer.updateOverride(for: "childView", with: AnyView(Text("Overridden View")))
+/// maintainer.overrideView(AnyView(Text("Overridden View")), for: "childView")
 ///
 /// if let override = maintainer.override(for: "childView") {
 ///     // Use the overridden view
@@ -43,18 +43,30 @@ public class OverridesMaintainer {
     /// Initializes a new instance of `OverridesMaintainer`.
     public init() {}
 
-    /// Updates the override for a specific key.
+    /// Overrides the view for a specific key.
     ///
     /// - Parameters:
-    ///   - key: The key associated with the override.
     ///   - view: The view to override with, wrapped in `AnyView`.
+    ///   - key: The key associated with the override.
     ///
     /// ### Example:
     /// ```swift
-    /// maintainer.updateOverride(for: "childView", with: AnyView(Text("Overridden View")))
+    /// maintainer.overrideView(AnyView(Text("Overridden View")), for: "childView")
     /// ```
-    public func updateOverride(for key: String, with view: AnyView) {
+    public func overrideView(_ view: AnyView, for key: String) {
         overrides[key] = view
+    }
+
+    /// Removes the override for a specific key if it exists.
+    ///
+    /// - Parameter key: The key whose override should be removed.
+    public func removeOverride(for key: String) {
+        overrides.removeValue(forKey: key)
+    }
+
+    /// Resets all overrides.
+    public func resetAll() {
+        overrides.removeAll()
     }
 
     /// Retrieves the override for a specific key, if it exists.

--- a/Sources/InjectableViewsMacros/InjectableContainerMacro.swift
+++ b/Sources/InjectableViewsMacros/InjectableContainerMacro.swift
@@ -112,15 +112,29 @@ public struct InjectableContainerMacro: MemberMacro {
         // Generate the InjectableKeys enum
         let injectableKeysEnum = try generateInjectableKeysEnum(from: declaration, in: context)
 
-        // Inject a function to update the overrides
-        let updateFunction = try DeclSyntax(stringLiteral: """
+        // Inject functions to manage overrides
+        let overrideFunction = try DeclSyntax(stringLiteral: """
         public func overrideView<V: View>(for key: InjectableKeys, @ViewBuilder with viewBuilder: () -> V) -> Self {
-            _overridesMaintainer.updateOverride(for: key.rawValue, with: AnyView(viewBuilder()))
+            _overridesMaintainer.overrideView(AnyView(viewBuilder()), for: key.rawValue)
             return self
         }
         """)
 
-        return [overridesMaintainerProperty, injectableKeysEnum, updateFunction]
+        let removeFunction = try DeclSyntax(stringLiteral: """
+        public func removeOverride(for key: InjectableKeys) -> Self {
+            _overridesMaintainer.removeOverride(for: key.rawValue)
+            return self
+        }
+        """)
+
+        let resetFunction = try DeclSyntax(stringLiteral: """
+        public func resetOverrides() -> Self {
+            _overridesMaintainer.resetAll()
+            return self
+        }
+        """)
+
+        return [overridesMaintainerProperty, injectableKeysEnum, overrideFunction, removeFunction, resetFunction]
     }
 
     /// Generates the `InjectableKeys` enum based on `@InjectableView` annotated members.

--- a/Tests/InjectableViewsTests/InjectableContainerMacroTests.swift
+++ b/Tests/InjectableViewsTests/InjectableContainerMacroTests.swift
@@ -23,14 +23,24 @@ final class InjectableContainerMacroTests: XCTestCase {
             }
             """,
             expandedSource: """
-                private var _overridesMaintainer = OverridesMaintainer()
+                private let _overridesMaintainer = OverridesMaintainer()
 
                 public enum InjectableKeys: String {
                     case childView = "childView"
                 }
 
                 public func overrideView<V: View>(for key: InjectableKeys, @ViewBuilder with viewBuilder: () -> V) -> Self {
-                    _overridesMaintainer.updateOverride(for: key.rawValue, with: AnyView(viewBuilder()))
+                    _overridesMaintainer.overrideView(AnyView(viewBuilder()), for: key.rawValue)
+                    return self
+                }
+
+                public func removeOverride(for key: InjectableKeys) -> Self {
+                    _overridesMaintainer.removeOverride(for: key.rawValue)
+                    return self
+                }
+
+                public func resetOverrides() -> Self {
+                    _overridesMaintainer.resetAll()
                     return self
                 }
             """,

--- a/Tests/InjectableViewsTests/OverridesMaintainerTests.swift
+++ b/Tests/InjectableViewsTests/OverridesMaintainerTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+import SwiftUI
+@testable import InjectableViews
+
+final class OverridesMaintainerTests: XCTestCase {
+    func testRemoveOverride() {
+        let maintainer = OverridesMaintainer()
+        maintainer.overrideView(AnyView(Text("A")), for: "key")
+        XCTAssertNotNil(maintainer.override(for: "key"))
+        maintainer.removeOverride(for: "key")
+        XCTAssertNil(maintainer.override(for: "key"))
+    }
+
+    func testResetAll() {
+        let maintainer = OverridesMaintainer()
+        maintainer.overrideView(AnyView(Text("A")), for: "key1")
+        maintainer.overrideView(AnyView(Text("B")), for: "key2")
+        XCTAssertNotNil(maintainer.override(for: "key1"))
+        XCTAssertNotNil(maintainer.override(for: "key2"))
+        maintainer.resetAll()
+        XCTAssertNil(maintainer.override(for: "key1"))
+        XCTAssertNil(maintainer.override(for: "key2"))
+    }
+}


### PR DESCRIPTION
## Summary
- add override removal and reset methods to `OverridesMaintainer`
- expose override management helpers from `InjectableContainer` macro
- cover override removal and reset in unit tests

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/apple/swift-syntax.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b762a820832ea1789bd07d60fb43